### PR TITLE
Fix auction prices when first item is a stack

### DIFF
--- a/MoLibAH.lua
+++ b/MoLibAH.lua
@@ -116,12 +116,12 @@ function ML:AHGetAuctionInfoByLink(itemLink)
         res.numAuctions = res.numAuctions + 1
         local bid = bidAmount or minBid
         if not res.minBid then
-          res.minBid = bid
+          res.minBid = self:round(bid / itemCount, .1)
         else
           res.minBid = self:round(math.min(res.minBid, bid / itemCount), .1)
         end
         if not res.minBuyout then
-          res.minBuyout = buyoutPrice -- could also be nil
+          res.minBuyout = self:round(buyoutPrice / itemCount), .1) -- could also be nil
         elseif buyoutPrice then
           res.minBuyout = self:round(math.min(res.minBuyout, buyoutPrice / itemCount), .1)
         end


### PR DESCRIPTION
When comparing item prices, the lib divides auction price by stack size to yield item price. But on the first auction of an item, it uses full auction price, which yields stack size*item price not item price.